### PR TITLE
Optimize posts fetch

### DIFF
--- a/frontend/lib/getPosts.js
+++ b/frontend/lib/getPosts.js
@@ -23,20 +23,16 @@ export async function getAllPosts() {
   const response = await fetch(`${process.env.BACKEND_URI}/posts?page=0&size=1`)
   const respJson = await response.json()
   const totalItems = respJson['total']
-  const TotalPages = Math.trunc(totalItems / pageSize)
+  const totalPages = Math.ceil(totalItems / pageSize)
 
-  const allPosts = []
-  let page = 0;
+  const fetchPages = []
+  for (let page = 0; page < totalPages; page++) {
+    const url = `${process.env.BACKEND_URI}/posts?page=${page}&size=${pageSize}`
+    fetchPages.push(fetch(url).then(res => res.json()))
+  }
 
-  while ( page <= TotalPages ) {
-    const responsePosts = await fetch(process.env.BACKEND_URI + "/posts?" + "page=" + page + "&size=" + pageSize);
-    const respPostsJson = await responsePosts.json();
-    const posts = respPostsJson['items']
-    posts.forEach(element => allPosts.push(element));
-
-    page++
-
-  };
+  const pagesData = await Promise.all(fetchPages)
+  const allPosts = pagesData.flatMap(p => p['items'])
 
   return allPosts
 }


### PR DESCRIPTION
## Summary
- make fetching posts in parallel for better performance

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683a78011bf8832abd9e7c660398f3dd