### PR TITLE
Optimize posts fetch

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     SECRET_KEY: Optional[str]
     ORIGINS: Optional[str]
     TEST_SQLALCHEMY_DATABASE_URI: Optional[PostgresDsn]
+    API_V1_STR: str = "/api/v1"
 
     class Config:
         env_file = ".env"

--- a/backend/app/models/post.py
+++ b/backend/app/models/post.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, Integer, String
+from sqlalchemy import TIMESTAMP, Integer, String, Index
 from sqlalchemy.sql.schema import Column, ForeignKey
 
 from app.db.base import Base
@@ -10,6 +10,9 @@ from . import user
 
 class Post(Base):
     __tablename__: str = "posts"
+    __table_args__ = (
+        Index("idx_post_author", "author_id"),
+    )
 
     id: int = Column(Integer, primary_key=True, index=True)
     author_id: int = Column(ForeignKey(user.User.id), nullable=False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from app.routers import users
 
 from backend.app.db.session import engine
 from backend.app.routers import posts
+from backend.app.config import settings
 
 # Create database tables to start
 # models.Base.metadata.create_all(bind=engine)
@@ -59,5 +60,11 @@ if otel_trace == "True":  # pragma: no cover
 else:
     pass
 
-app.include_router(posts.router)
-app.include_router(users.router)
+app.include_router(
+    users.router,
+    prefix=settings.API_V1_STR,
+)
+app.include_router(
+    posts.router,
+    prefix=settings.API_V1_STR,
+)

--- a/frontend/lib/getPosts.js
+++ b/frontend/lib/getPosts.js
@@ -6,7 +6,7 @@ import readingTime from 'reading-time'
 
 import MDXComponents from '../components/MDXComponents'
 
-const ITEMS_PAGE = 20
+const PAGE_SIZE = 50
 
 
 export async function getPosts() {
@@ -18,25 +18,19 @@ export async function getPosts() {
 }
 
 export async function getAllPosts() {
-
-  const pageSize = 50
   const response = await fetch(`${process.env.BACKEND_URI}/posts?page=0&size=1`)
   const respJson = await response.json()
   const totalItems = respJson['total']
-  const TotalPages = Math.trunc(totalItems / pageSize)
+  const totalPages = Math.ceil(totalItems / PAGE_SIZE)
 
-  const allPosts = []
-  let page = 0;
+  const fetchPages = []
+  for (let page = 0; page < totalPages; page++) {
+    const url = `${process.env.BACKEND_URI}/posts?page=${page}&size=${PAGE_SIZE}`
+    fetchPages.push(fetch(url).then(res => res.json()))
+  }
 
-  while ( page <= TotalPages ) {
-    const responsePosts = await fetch(process.env.BACKEND_URI + "/posts?" + "page=" + page + "&size=" + pageSize);
-    const respPostsJson = await responsePosts.json();
-    const posts = respPostsJson['items']
-    posts.forEach(element => allPosts.push(element));
-
-    page++
-
-  };
+  const pagesData = await Promise.all(fetchPages)
+  const allPosts = pagesData.flatMap(p => p['items'])
 
   return allPosts
 }
@@ -71,7 +65,7 @@ export async function getPostBySlug(slug) {
   return {
     mdxSource,
     frontMatter: {
-      wordCount: content.split(/\+s/gu).length,
+      wordCount: content.split(/\s+/gu).length,
       readingTime: readingTime(content),
       slug: slug || null,
       ...data


### PR DESCRIPTION
## Summary
- make fetching posts in parallel for better performance
- add API route prefix configuration
- create an index for Post.author_id
- fix word-count parsing and remove unused constant

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_683a78011bf8832abd9e7c660398f3dd