### PR TITLE
Optimize posts fetch

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -18,7 +18,7 @@ import {
 } from '@chakra-ui/react';
 
 import Container from '../components/Container';
-import { getPosts, getAllPosts } from '../lib/getPosts';
+import { getPosts, getAllPosts, PAGE_SIZE } from '../lib/getPosts';
 import BlogPost from '../components/BlogPost';
 
 import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
@@ -27,9 +27,8 @@ export default function Blog({ posts }) {
   const BlogPosts = posts['items'];
   console.log(posts['total']);
   const totalItems = posts['total'];
-  const pageSize = 50;
-  const TotalPages = Math.trunc(totalItems / pageSize);
-  const ListPages = [...Array(TotalPages + 1).keys()];
+  const totalPages = Math.ceil(totalItems / PAGE_SIZE);
+  const ListPages = [...Array(totalPages).keys()];
   console.log(ListPages);
   return (
     <>


### PR DESCRIPTION
## Summary
- unify pagination constants for posts fetch logic
- fix word count extraction in MDX renderer

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683a78011bf8832abd9e7c660398f3dd