### PR TITLE
Fix template links and request URLs

### DIFF
--- a/app/templates/500.html
+++ b/app/templates/500.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}404 - 页面未找到{% endblock %}
+{% block title %}500 - 服务器错误{% endblock %}
 
 {% block content %}
 <div class="py-5 text-center">
-    <h1 class="display-1">404</h1>
-    <p class="lead">抱歉，您请求的页面不存在。</p>
+    <h1 class="display-1">500</h1>
+    <p class="lead">服务器内部错误，请稍后再试。</p>
     <a href="/" class="btn btn-primary">返回首页</a>
 </div>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,10 +47,10 @@
             </div>
             <div class="card-body">
                 <ul class="list-group list-group-flush">
-                    {% for category in categories %}
+                    {% for category, count in categories %}
                         <li class="list-group-item d-flex justify-content-between align-items-center">
                             <a href="/?category_id={{ category.id }}" class="text-decoration-none">{{ category.name }}</a>
-                            <span class="badge bg-primary rounded-pill">{{ category.posts|length }}</span>
+                            <span class="badge bg-primary rounded-pill">{{ count }}</span>
                         </li>
                     {% endfor %}
                 </ul>

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -13,7 +13,8 @@ document.addEventListener('DOMContentLoaded', function() {
         loginError.classList.add('d-none');
 
         try {
-            const response = await axios.post('auth/login',
+            // 使用绝对路径以便与默认 baseURL 拼接
+            const response = await axios.post('/auth/login',
                 new URLSearchParams({
                     'username': email,  // API接收username参数，但我们使用email
                     'password': password

--- a/static/js/post.js
+++ b/static/js/post.js
@@ -20,7 +20,8 @@ document.addEventListener('DOMContentLoaded', function() {
             commentError.classList.add('d-none');
 
             try {
-                const response = await axios.post(`/api/v1/posts/${postId}/comments`, {
+                // 使用相对路径以配合默认 baseURL
+                const response = await axios.post(`/posts/${postId}/comments`, {
                     content: content,
                     post_id: postId
                 });
@@ -70,7 +71,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const loadRelatedPosts = async () => {
             try {
                 const postSlug = window.location.pathname.split('/').pop();
-                const response = await axios.get(`/api/v1/posts/${postSlug}/related`);
+                // 仍然使用相对路径以配合 baseURL
+                const response = await axios.get(`/posts/${postSlug}/related`);
 
                 const relatedPosts = response.data;
                 if (relatedPosts.length === 0) {

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -31,9 +31,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 username: username,
                 email: email,
                 password: password,
-                is_active: true,      // 添加
-    is_superuser: false   // 添加
-            }, { baseURL: '' }); // 临时禁用 baseURL
+                is_active: true,
+                is_superuser: false
+            });
 
 
             // 注册成功，重定向到登录页


### PR DESCRIPTION
## Summary
- make 404 page use base template and add missing 500 template
- show category post counts correctly on the index page
- fix login/register/post request URLs so Axios baseURL works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d096d6784832a9aee3031bd4ecaa0