### PR TITLE
Add routes for new template pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -767,3 +767,152 @@ async def user_profile_page(
             # 您可以根据需要传递更多用户相关的统计信息或数据
         }
     )
+
+
+# ---------------------------------------------------------------------------
+# Public informational pages
+# ---------------------------------------------------------------------------
+
+
+@app.get("/about", response_class=HTMLResponse)
+async def about_page(request: Request, current_user: Optional[User] = Depends(get_current_user_optional)):
+    return templates.TemplateResponse(
+        "about.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "user_is_authenticated": current_user is not None,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+@app.get("/contact", response_class=HTMLResponse)
+async def contact_page(request: Request, current_user: Optional[User] = Depends(get_current_user_optional)):
+    return templates.TemplateResponse(
+        "contact.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "user_is_authenticated": current_user is not None,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+@app.get("/privacy", response_class=HTMLResponse)
+async def privacy_page(request: Request, current_user: Optional[User] = Depends(get_current_user_optional)):
+    return templates.TemplateResponse(
+        "privacy.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "user_is_authenticated": current_user is not None,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Password recovery and email verification pages
+# ---------------------------------------------------------------------------
+
+
+@app.get("/forgot-password", response_class=HTMLResponse)
+async def forgot_password_page(request: Request):
+    return templates.TemplateResponse(
+        "forgot_password.html",
+        {"request": request, "current_year": datetime.now().year},
+    )
+
+
+@app.get("/reset-password", response_class=HTMLResponse)
+async def reset_password_page(request: Request, token: Optional[str] = None):
+    return templates.TemplateResponse(
+        "reset_password.html",
+        {
+            "request": request,
+            "token": token,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+@app.get("/email-verified", response_class=HTMLResponse)
+async def email_verified_notice_page(request: Request):
+    return templates.TemplateResponse(
+        "email_verified_notice.html",
+        {"request": request, "current_year": datetime.now().year},
+    )
+
+
+@app.get("/email-verification-feedback", response_class=HTMLResponse)
+async def verification_feedback_page(request: Request, success: bool = True):
+    return templates.TemplateResponse(
+        "verification_feedback.html",
+        {
+            "request": request,
+            "success": success,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin management pages
+# ---------------------------------------------------------------------------
+
+
+@app.get("/dashboard/categories", response_class=HTMLResponse)
+async def dashboard_categories_page(
+    request: Request,
+    current_user: User = Depends(get_dashboard_user),
+):
+    if isinstance(current_user, RedirectResponse):
+        return current_user
+
+    return templates.TemplateResponse(
+        "dashboard/categories_manage.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+@app.get("/dashboard/tags", response_class=HTMLResponse)
+async def dashboard_tags_page(
+    request: Request,
+    current_user: User = Depends(get_dashboard_user),
+):
+    if isinstance(current_user, RedirectResponse):
+        return current_user
+
+    return templates.TemplateResponse(
+        "dashboard/tags_manage.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "current_year": datetime.now().year,
+        },
+    )
+
+
+@app.get("/dashboard/users", response_class=HTMLResponse)
+async def dashboard_users_page(
+    request: Request,
+    current_user: User = Depends(get_dashboard_user),
+):
+    if isinstance(current_user, RedirectResponse):
+        return current_user
+
+    return templates.TemplateResponse(
+        "dashboard/users_manage.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "current_year": datetime.now().year,
+        },
+    )
+

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}关于我们 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="container mt-section">
+    <div class="content-panel" style="padding: var(--spacing-xl);">
+        <h1 class="section-title mb-3">关于我们</h1>
+        <p class="lead text-secondary">这里是关于 Async Blog 的介绍内容。</p>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -87,9 +87,9 @@
         <div class="container footer-content"> {# 使用新CSS中的 .footer-content #}
             {# 您可以在新 CSS 中为 .footer-links 创建样式，或者在这里直接写链接 #}
             <div class="footer-links mb-3">
-                <a href="#" class="footer-link">关于我们</a>
-                <a href="#" class="footer-link">联系方式</a>
-                <a href="#" class="footer-link">隐私政策</a>
+                <a href="/about" class="footer-link">关于我们</a>
+                <a href="/contact" class="footer-link">联系方式</a>
+                <a href="/privacy" class="footer-link">隐私政策</a>
             </div>
             <p class="mb-0">&copy; {{ current_year }} Async Blog. All rights reserved.</p>
         </div>

--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}联系方式 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="container mt-section">
+    <div class="content-panel" style="padding: var(--spacing-xl);">
+        <h1 class="section-title mb-3">联系方式</h1>
+        <p class="lead text-secondary">在这里放置您的联系信息或反馈表单。</p>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/dashboard/categories_manage.html
+++ b/app/templates/dashboard/categories_manage.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}分类管理 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="row mt-section">
+    <div class="col-md-3">
+        <nav class="dashboard-nav sidebar-card p-0">
+            <a href="/dashboard" class="dashboard-nav-link">仪表盘总览</a>
+            <a href="/dashboard/posts" class="dashboard-nav-link">我的文章</a>
+            <a href="/dashboard/posts/new" class="dashboard-nav-link">发布新文章</a>
+            <a href="/dashboard/profile" class="dashboard-nav-link">个人资料</a>
+            <a href="/dashboard/categories" class="dashboard-nav-link active">分类管理</a>
+            <a href="/dashboard/tags" class="dashboard-nav-link">标签管理</a>
+            <a href="/dashboard/users" class="dashboard-nav-link">用户管理</a>
+        </nav>
+    </div>
+    <div class="col-md-9">
+        <section class="content-panel">
+            <h3 class="section-title mb-4">分类管理</h3>
+            <!-- TODO: 分类管理功能 -->
+        </section>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/dashboard/tags_manage.html
+++ b/app/templates/dashboard/tags_manage.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}标签管理 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="row mt-section">
+    <div class="col-md-3">
+        <nav class="dashboard-nav sidebar-card p-0">
+            <a href="/dashboard" class="dashboard-nav-link">仪表盘总览</a>
+            <a href="/dashboard/posts" class="dashboard-nav-link">我的文章</a>
+            <a href="/dashboard/posts/new" class="dashboard-nav-link">发布新文章</a>
+            <a href="/dashboard/profile" class="dashboard-nav-link">个人资料</a>
+            <a href="/dashboard/categories" class="dashboard-nav-link">分类管理</a>
+            <a href="/dashboard/tags" class="dashboard-nav-link active">标签管理</a>
+            <a href="/dashboard/users" class="dashboard-nav-link">用户管理</a>
+        </nav>
+    </div>
+    <div class="col-md-9">
+        <section class="content-panel">
+            <h3 class="section-title mb-4">标签管理</h3>
+            <!-- TODO: 标签管理功能 -->
+        </section>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/dashboard/users_manage.html
+++ b/app/templates/dashboard/users_manage.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}用户管理 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="row mt-section">
+    <div class="col-md-3">
+        <nav class="dashboard-nav sidebar-card p-0">
+            <a href="/dashboard" class="dashboard-nav-link">仪表盘总览</a>
+            <a href="/dashboard/posts" class="dashboard-nav-link">我的文章</a>
+            <a href="/dashboard/posts/new" class="dashboard-nav-link">发布新文章</a>
+            <a href="/dashboard/profile" class="dashboard-nav-link">个人资料</a>
+            <a href="/dashboard/categories" class="dashboard-nav-link">分类管理</a>
+            <a href="/dashboard/tags" class="dashboard-nav-link">标签管理</a>
+            <a href="/dashboard/users" class="dashboard-nav-link active">用户管理</a>
+        </nav>
+    </div>
+    <div class="col-md-9">
+        <section class="content-panel">
+            <h3 class="section-title mb-4">用户管理</h3>
+            <!-- TODO: 用户管理功能 -->
+        </section>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/email/email_verification_email.html
+++ b/app/templates/email/email_verification_email.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>邮箱验证</title>
+</head>
+<body>
+    <p>您好，{{ user.username }}，</p>
+    <p>欢迎加入 Async Blog！请点击以下链接验证您的邮箱：</p>
+    <p><a href="{{ verify_link }}">{{ verify_link }}</a></p>
+    <p>如果您并未注册账户，请忽略此邮件。</p>
+</body>
+</html>

--- a/app/templates/email/password_reset_email.html
+++ b/app/templates/email/password_reset_email.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>密码重置</title>
+</head>
+<body>
+    <p>您好，{{ user.username }}，</p>
+    <p>我们收到了您的密码重置请求。请点击以下链接设置新的密码：</p>
+    <p><a href="{{ reset_link }}">{{ reset_link }}</a></p>
+    <p>如果您并未请求此操作，请忽略此邮件。</p>
+    <p>感谢使用 Async Blog！</p>
+</body>
+</html>

--- a/app/templates/email_verified_notice.html
+++ b/app/templates/email_verified_notice.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}邮箱验证 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="container mt-section text-center">
+    <div class="content-panel" style="padding: var(--spacing-xl);">
+        <h1 class="section-title mb-3">注册成功！</h1>
+        <p class="lead text-secondary">我们已向您的邮箱发送了一封验证邮件，请前往查收并完成验证。</p>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/forgot_password.html
+++ b/app/templates/forgot_password.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}找回密码 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="form-container mt-section">
+    <header class="form-header text-center mb-4">
+        <h2 class="section-title">找回密码</h2>
+        <p class="text-secondary">请输入注册邮箱，我们将发送重置链接。</p>
+    </header>
+
+    <div id="forgot-error" class="form-message error d-none"></div>
+    <div id="forgot-success" class="form-message success d-none"></div>
+
+    <form id="forgot-password-form">
+        <div class="mb-3">
+            <label for="email" class="form-label">邮箱</label>
+            <input type="email" id="email" class="form-control" required placeholder="you@example.com">
+        </div>
+        <div class="d-grid mt-4">
+            <button type="submit" class="btn btn-primary w-100">发送重置链接</button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/privacy.html
+++ b/app/templates/privacy.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}隐私政策 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="container mt-section">
+    <div class="content-panel" style="padding: var(--spacing-xl);">
+        <h1 class="section-title mb-3">隐私政策</h1>
+        <p class="lead text-secondary">在此页面描述您网站的隐私政策。</p>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}重置密码 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="form-container mt-section">
+    <header class="form-header text-center mb-4">
+        <h2 class="section-title">重置密码</h2>
+    </header>
+
+    <div id="reset-error" class="form-message error d-none"></div>
+    <div id="reset-success" class="form-message success d-none"></div>
+
+    <form id="reset-password-form">
+        <div class="mb-3">
+            <label for="password" class="form-label">新密码</label>
+            <input type="password" id="password" class="form-control" required placeholder="请输入新密码">
+        </div>
+        <div class="mb-3">
+            <label for="confirm-password" class="form-label">确认新密码</label>
+            <input type="password" id="confirm-password" class="form-control" required placeholder="再次输入新密码">
+        </div>
+        <div class="d-grid mt-4">
+            <button type="submit" class="btn btn-primary w-100">重置密码</button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/verification_feedback.html
+++ b/app/templates/verification_feedback.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}邮箱验证结果 - Async Blog{% endblock %}
+
+{% block content %}
+<div class="container mt-section text-center">
+    <div class="content-panel" style="padding: var(--spacing-xl);">
+        {% if success %}
+        <h1 class="section-title mb-3">邮箱验证成功！</h1>
+        <p class="lead text-secondary">感谢您的确认，您现在可以登录并享受完整功能。</p>
+        {% else %}
+        <h1 class="section-title mb-3">邮箱验证失败</h1>
+        <p class="lead text-secondary">链接无效或已过期，请重新注册或请求新的验证链接。</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create placeholder HTML templates for password reset, verification, admin management, and static pages
- link footer to about, contact, and privacy pages
- provide FastAPI routes for all new templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683de6bfeb10832abcd4946417d9357f